### PR TITLE
Add MCP server with FastAPI and Fly.io configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use official Python image
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY ./app ./app
+
+EXPOSE 8080
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,125 @@
-# aiembedded-email-mcp
+# AIEmbedded Email MCP
+
+A custom Mail Control Panel (MCP) server for ChatGPT that connects to your IONOS email account (`info@aiembedded.tech`). It exposes a simple HTTP API that allows ChatGPT or other clients to fetch recent emails and save draft replies. This repository contains the FastAPI application, Dockerfile, Fly.io configuration, and supporting files so you can deploy the service quickly.
+
+## Features
+
+- **Fetch recent emails** – Lists the most recent messages from your IONOS inbox (default 5) using IMAP. Returns sender, recipient, subject, and a snippet of the body.
+- **Save draft replies** – Takes a destination address, subject and body, and stores the message in your IONOS "Drafts" folder using IMAP. Drafts are available when you open your mailbox.
+- **Environment based credentials** – Email address and password are provided via environment variables (`EMAIL` and `PASSWORD`) and are not hard‑coded in the repository.
+- **Ready for Fly.io** – Includes a `Dockerfile` and `fly.toml` for deployment to Fly.io.
+
+## Requirements
+
+- Python 3.11
+- IONOS email account credentials
+- IMAP and SMTP access enabled on your IONOS account
+
+## Setup (Local)
+
+1. Clone the repository and navigate into it.
+
+   ```bash
+   git clone https://github.com/Abhinav330/aiembedded-email-mcp.git
+   cd aiembedded-email-mcp
+   ```
+
+2. Install dependencies.
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Set the required environment variables in your shell.
+
+   ```bash
+   export EMAIL=info@aiembedded.tech
+   export PASSWORD=your_email_password
+   ```
+
+4. Start the server with Uvicorn.
+
+   ```bash
+   uvicorn app.main:app --host 0.0.0.0 --port 8080
+   ```
+
+## Docker
+
+You can run the service inside a container using the provided `Dockerfile`.
+
+```bash
+# Build the image
+docker build -t aiembedded-email-mcp .
+
+# Run the container
+docker run -e EMAIL=info@aiembedded.tech -e PASSWORD=your_email_password -p 8080:8080 aiembedded-email-mcp
+```
+
+## Deployment on Fly.io
+
+1. Install the Fly.io CLI and log in.
+
+   ```bash
+   curl -L https://fly.io/install.sh | sh
+   fly auth login
+   ```
+
+2. Create and configure the app (once).
+
+   ```bash
+   fly launch --name aiembedded-email-mcp --no-deploy
+   ```
+
+3. Set secrets for your email credentials.
+
+   ```bash
+   fly secrets set EMAIL=info@aiembedded.tech PASSWORD=your_email_password
+   ```
+
+4. Deploy the application.
+
+   ```bash
+   fly deploy
+   ```
+
+Once deployed, your API will be available at `https://<your-app-name>.fly.dev`.
+
+## API Endpoints
+
+### `GET /emails`
+
+Fetches the most recent emails from your IONOS inbox.
+
+**Query Parameters:**
+
+- `limit` (optional, default: 5) – The number of messages to return.
+
+**Example:**
+
+```
+GET https://<your-app-name>.fly.dev/emails?limit=5
+```
+
+### `POST /drafts`
+
+Saves a draft reply in your IONOS account.
+
+**Request body (JSON):**
+
+```json
+{
+  "to": "recipient@example.com",
+  "subject": "Hello",
+  "body": "This is a draft reply"
+}
+```
+
+**Example:**
+
+```
+POST https://<your-app-name>.fly.dev/drafts
+```
+
+## Contributing
+
+Feel free to open issues or pull requests if you find bugs or have suggestions for improvements.

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -1,0 +1,1 @@
+# Placeholder module for future email parsing, formatting, etc.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,74 @@
+from fastapi import FastAPI
+import imaplib
+import smtplib
+import email
+from email.mime.text import MIMEText
+import os
+
+app = FastAPI()
+
+IMAP_HOST = "imap.ionos.com"
+SMTP_HOST = "smtp.ionos.com"
+EMAIL = os.getenv("EMAIL")
+PASSWORD = os.getenv("PASSWORD")
+
+
+@app.get("/")
+def home():
+    return {"status": "Email MCP Server running"}
+
+
+@app.get("/emails")
+def fetch_emails(limit: int = 5):
+    conn = imaplib.IMAP4_SSL(IMAP_HOST)
+    conn.login(EMAIL, PASSWORD)
+    conn.select("INBOX")
+
+    # Fetch the latest emails
+    status, data = conn.search(None, "ALL")
+    mail_ids = data[0].split()[-limit:]
+    emails = []
+    for mid in reversed(mail_ids):
+        status, msg_data = conn.fetch(mid, "(RFC822)")
+        raw = msg_data[0][1]
+        msg = email.message_from_bytes(raw)
+
+        snippet = ""
+        if msg.is_multipart():
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain":
+                    payload = part.get_payload(decode=True)
+                    if payload:
+                        snippet = payload[:200].decode(errors="ignore")
+                    break
+        else:
+            payload = msg.get_payload(decode=True)
+            if payload:
+                snippet = payload[:200].decode(errors="ignore")
+
+        emails.append({
+            "from": msg["From"],
+            "to": msg["To"],
+            "subject": msg["Subject"],
+            "snippet": snippet
+        })
+
+    conn.close()
+    conn.logout()
+    return {"emails": emails}
+
+
+@app.post("/drafts")
+def create_draft(to: str, subject: str, body: str):
+    msg = MIMEText(body)
+    msg["From"] = EMAIL
+    msg["To"] = to
+    msg["Subject"] = subject
+
+    # Save to Drafts using IMAP APPEND
+    imap = imaplib.IMAP4_SSL(IMAP_HOST)
+    imap.login(EMAIL, PASSWORD)
+    imap.append("Drafts", "\\Draft", None, msg.as_bytes())
+    imap.logout()
+
+    return {"status": "draft_saved"}

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,19 @@
+app = "aiembedded-email-mcp"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+
+[[services]]
+  internal_port = 8080
+  processes = ["app"]
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
This pull request adds a working mail control panel (MCP) service to integrate ChatGPT with IONOS email. It includes:

- A FastAPI application (`app/main.py`) that exposes two endpoints:
  - **GET /emails**: fetches recent emails from the IONOS inbox using IMAP.
  - **POST /drafts**: saves a draft reply into the "Drafts" folder using IMAP.
- A placeholder module (`app/email_utils.py`) for future email parsing and formatting utilities.
- A `Dockerfile` for containerizing the service.
- A `fly.toml` configuration for deploying to Fly.io.
- A `.gitignore` and `requirements.txt`.
- A comprehensive `README.md` with instructions for local setup, Docker usage, Fly.io deployment, and API usage.

Let me know if you have any questions or would like any changes.
